### PR TITLE
Remove Assistant Deputy Commissioner rank

### DIFF
--- a/src/components/BadgeLookup.tsx
+++ b/src/components/BadgeLookup.tsx
@@ -19,20 +19,19 @@ type CertStatus = "LEAD" | "SUPER" | "CERT" | null;
 
 // Use rankOrder for comparisons
 const rankOrder: { [key: string]: number } = {
-  Commissioner: 1,
-  "Assistant Deputy Commissioner": 2,
-  "Deputy Commissioner": 3,
-  "Assistant Commissioner": 4,
-  Commander: 5,
-  Captain: 6,
-  Lieutenant: 7, // Command starts here
-  "Staff Sergeant": 8,
-  Sergeant: 9, // Supervisors start here
-  Corporal: 10,
-  "Trooper First Class": 11,
-  Trooper: 12,
-  Cadet: 13,
-  Unknown: 99,
+  "Commissioner": 1,
+  "Deputy Commissioner": 2,
+  "Assistant Commissioner": 3,
+  "Commander": 4,
+  "Captain": 5,
+  "Lieutenant": 6,
+  "Staff Sergeant": 7,
+  "Sergeant": 8,
+  "Corporal": 9,
+  "Trooper First Class": 10,
+  "Trooper": 11,
+  "Cadet": 12,
+  "Unknown": 99,
 };
 
 interface RosterUser {

--- a/src/components/Fleet.tsx
+++ b/src/components/Fleet.tsx
@@ -13,20 +13,19 @@ import { User as AuthUser } from "../types/User";
 type CertStatus = "LEAD" | "SUPER" | "CERT" | null;
 
 const rankOrder: { [key: string]: number } = {
-  Commissioner: 1,
-  "Assistant Deputy Commissioner": 2,
-  "Deputy Commissioner": 3,
-  "Assistant Commissioner": 4,
-  Commander: 5,
-  Captain: 6,
-  Lieutenant: 7,
-  "Staff Sergeant": 8,
-  Sergeant: 9,
-  Corporal: 10,
-  "Trooper First Class": 11,
-  Trooper: 12,
-  Cadet: 13,
-  Unknown: 99,
+  "Commissioner": 1,
+  "Deputy Commissioner": 2,
+  "Assistant Commissioner": 3,
+  "Commander": 4,
+  "Captain": 5,
+  "Lieutenant": 6,
+  "Staff Sergeant": 7,
+  "Sergeant": 8,
+  "Corporal": 9,
+  "Trooper First Class": 10,
+  "Trooper": 11,
+  "Cadet": 12,
+  "Unknown": 99,
 };
 
 interface RosterUser {

--- a/src/components/RosterManagement.tsx
+++ b/src/components/RosterManagement.tsx
@@ -51,15 +51,14 @@ const formatDateForDisplay = (
 const rankCategories: { [key: string]: string[] } = {
   "High Command": [
     "Commissioner",
-    "Assistant Deputy Commissioner",
     "Deputy Commissioner",
     "Assistant Commissioner",
     "Commander",
   ],
-  Command: ["Captain", "Lieutenant"],
-  Supervisors: ["Staff Sergeant", "Sergeant"],
+  "Command": ["Captain", "Lieutenant"],
+  "Supervisors": ["Staff Sergeant", "Sergeant"],
   "State Troopers": ["Corporal", "Trooper First Class", "Trooper"],
-  Cadets: ["Cadet"],
+  "Cadets": ["Cadet"],
 };
 
 const categoryOrder = [

--- a/src/components/SASPRoster.tsx
+++ b/src/components/SASPRoster.tsx
@@ -18,15 +18,14 @@ import {
 const rankCategories: { [key: string]: string[] } = {
   "High Command": [
     "Commissioner",
-    "Assistant Deputy Commissioner",
     "Deputy Commissioner",
     "Assistant Commissioner",
     "Commander",
   ],
-  Command: ["Captain", "Lieutenant"],
-  Supervisors: ["Staff Sergeant", "Sergeant"],
+  "Command": ["Captain", "Lieutenant"],
+  "Supervisors": ["Staff Sergeant", "Sergeant"],
   "State Troopers": ["Corporal", "Trooper First Class", "Trooper"],
-  Cadets: ["Cadet"],
+  "Cadets": ["Cadet"],
 };
 
 const categoryOrder = [

--- a/src/data/FullRosterData.ts
+++ b/src/data/FullRosterData.ts
@@ -77,7 +77,7 @@ const fullRosterTemplate: RosterTemplateEntry[] = [
     loaEndDate: null,
     loaStartDate: null,
     name: "VACANT",
-    rank: "Assistant Deputy Commissioner",
+    rank: "Deputy Commissioner",
     role: "",
   },
   {
@@ -201,7 +201,7 @@ const fullRosterTemplate: RosterTemplateEntry[] = [
     role: "",
   },
   {
-    badge: "204",
+    badge: "",
     callsign: "1K-100",
     certifications: {
       ACU: "CERT",

--- a/src/data/rosterConfig.ts
+++ b/src/data/rosterConfig.ts
@@ -55,20 +55,19 @@ export const formatLoaRange = (
 export type CertStatus = "LEAD" | "SUPER" | "CERT" | null;
 
 export const rankOrder: { [key: string]: number } = {
-  Commissioner: 1,
-  "Assistant Deputy Commissioner": 2,
-  "Deputy Commissioner": 3,
-  "Assistant Commissioner": 4,
-  Commander: 5,
-  Captain: 6,
-  Lieutenant: 7,
-  "Staff Sergeant": 8,
-  Sergeant: 9,
-  Corporal: 10,
-  "Trooper First Class": 11,
-  Trooper: 12,
-  Cadet: 13,
-  Unknown: 99,
+  "Commissioner": 1,
+  "Deputy Commissioner": 2,
+  "Assistant Commissioner": 3,
+  "Commander": 4,
+  "Captain": 5,
+  "Lieutenant": 6,
+  "Staff Sergeant": 7,
+  "Sergeant": 8,
+  "Corporal": 9,
+  "Trooper First Class": 10,
+  "Trooper": 11,
+  "Cadet": 12,
+  "Unknown": 99,
 };
 
 export const certOptions: {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -22,20 +22,19 @@ const saspStar = "/SASPLOGO2.png";
 type CertStatus = "LEAD" | "SUPER" | "CERT" | null;
 
 const rankOrder: { [key: string]: number } = {
-  Commissioner: 1,
-  "Assistant Deputy Commissioner": 2,
-  "Deputy Commissioner": 3,
-  "Assistant Commissioner": 4,
-  Commander: 5,
-  Captain: 6,
-  Lieutenant: 7,
-  "Staff Sergeant": 8,
-  Sergeant: 9,
-  Corporal: 10,
-  "Trooper First Class": 11,
-  Trooper: 12,
-  Cadet: 13,
-  Unknown: 99,
+  "Commissioner": 1,
+  "Deputy Commissioner": 2,
+  "Assistant Commissioner": 3,
+  "Commander": 4,
+  "Captain": 5,
+  "Lieutenant": 6,
+  "Staff Sergeant": 7,
+  "Sergeant": 8,
+  "Corporal": 9,
+  "Trooper First Class": 10,
+  "Trooper": 11,
+  "Cadet": 12,
+  "Unknown": 99,
 };
 
 interface RosterUser {


### PR DESCRIPTION
Some consistency changes for RankOrder as well. We'll eventually want to stop defining this everywhere.